### PR TITLE
Correct port number in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ In the project directory, you can run:
 ### `yarn start`
 
 Runs the app in the development mode.
-Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
+Open [http://localhost:8080](http://localhost:8080) to view it in the browser.
 
 ### `yarn build`
 


### PR DESCRIPTION
Default port defined as 8080 in node_modules/webpack-dev-server/lib/Server.js